### PR TITLE
add missing dependency on ogg

### DIFF
--- a/depends/common/ogg/CMakeLists.txt
+++ b/depends/common/ogg/CMakeLists.txt
@@ -1,0 +1,14 @@
+project(ogg)
+
+cmake_minimum_required(VERSION 2.8)
+
+include(ExternalProject)
+externalproject_add(ogg
+                    SOURCE_DIR ${CMAKE_SOURCE_DIR}
+                    UPDATE_COMMAND ""
+                    CONFIGURE_COMMAND <SOURCE_DIR>/configure 
+                      --prefix=${OUTPUT_DIR}
+                    INSTALL_COMMAND ""
+                    BUILD_IN_SOURCE 1)
+                  
+install(CODE "execute_process(COMMAND make install WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})")

--- a/depends/common/ogg/ogg.txt
+++ b/depends/common/ogg/ogg.txt
@@ -1,0 +1,1 @@
+ogg http://mirrors.xbmc.org/build-deps/sources/libogg-1.1.4.tar.gz


### PR DESCRIPTION
This adds the missing `ogg` directory to `depends/common`. I simply copied the one from audioencoder.vorbis which also depends on ogg.

@wsnipex: Could you please check if this is ok with the new dependency handling?
