### PR TITLE
Fix calculation for the estimated total samples of the encoded file

### DIFF
--- a/src/EncoderFlac.cpp
+++ b/src/EncoderFlac.cpp
@@ -204,7 +204,7 @@ bool Start(void *ctx, int iInChannels, int iInRate, int iInBits,
   ok &= FLAC__stream_encoder_set_channels(context->encoder, iInChannels);
   ok &= FLAC__stream_encoder_set_bits_per_sample(context->encoder, iInBits);
   ok &= FLAC__stream_encoder_set_sample_rate(context->encoder, iInRate);
-  ok &= FLAC__stream_encoder_set_total_samples_estimate(context->encoder, (FLAC__uint64)iTrackLength * iInRate);
+  ok &= FLAC__stream_encoder_set_total_samples_estimate(context->encoder, iTrackLength / 4);
   ok &= FLAC__stream_encoder_set_compression_level(context->encoder, level);
 
   // now add some metadata


### PR DESCRIPTION
I noticed that ever since the merge of audioencoder binary addons the FLAC encoder didn't produce playable/valid files but it worked fine before. So I hunted down the only real change to the old code and that is the calculation of the estimated total samples of the encoded file. See https://github.com/Montellese/audioencoder.flac/commit/71ffcf71c679bca4e2c30cbc23a040ce56abad71 for the change and a detailed comment from me. I checked some files and these are the values of iTrackLength:
- 3m 05s = 185s: 32'725'728
- 2m 35s = 155s: 27'461'952
- 3m 23s = 203s: 35'849'184

So it looks like if that value is divided by `4` and then by the number of seconds of the track you end up at around `44100` which is the expected sample rate. So basically the calculation is

```
iTrackLength = <sample rate> * 4 * <total seconds>
```

so dividing `iTrackLength` by 4 will give the estimated total samples.

Since I can only test on win32 and @jmarshallnz made that change while developing on OSX and no other audioencoder makes use of `iTrackLength` maybe this is a platform-specific issue. So I'd be grateful if someone could test this on linux and OSX.
