### PR TITLE
[cmake] Rename find_package(kodi) to Kodi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 enable_language(CXX)
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 find_package(FLAC REQUIRED)
 find_package(Ogg REQUIRED)
 

--- a/audioencoder.flac/addon.xml.in
+++ b/audioencoder.flac/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audioencoder.flac"
-  version="1.0.0"
+  version="1.1.0"
   name="Flac Audio Encoder"
   provider-name="spiff">
   <requires>


### PR DESCRIPTION
Needed after https://github.com/xbmc/xbmc/pull/9750 goes in