### PR TITLE
[windows] bump flac to 1.3.2 to get it compiled on x64

### DIFF
--- a/depends/windows/flac/CMakeLists.txt
+++ b/depends/windows/flac/CMakeLists.txt
@@ -2,9 +2,15 @@ project(flac)
 
 cmake_minimum_required(VERSION 2.8)
 
-add_definitions(-DVERSION="1.2.1"
-                -DFLAC__NO_DLL -DFLAC__HAS_OGG -DFLAC__CPU_IA32 -DFLAC__HAS_NASM -DFLAC__USE_3DNOW
+add_definitions(-DPACKAGE_VERSION="1.3.2"
+                -DFLAC__NO_DLL -DFLAC__ALIGN_MALLOC_DATA -DFLAC__HAS_OGG -DFLAC__HAS_X86INTRIN
                 -Dfseeko=_fseeki64 -Dftello=_ftelli64) # work around a bug in the code that leads to "undefined reference errors"
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+  add_definitions(-DFLAC__CPU_IA32 -DFLAC__HAS_NASM)
+elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  add_definitions(-DENABLE_64_BIT_WORDS -DFLAC__CPU_X86_64)
+endif()
 
 # function to setup a custom command for a compiled assembler file
 function (build_nasm filename_we)
@@ -29,9 +35,15 @@ set(LIBFLAC_SOURCES src/libFLAC/bitmath.c
                     src/libFLAC/cpu.c
                     src/libFLAC/crc.c
                     src/libFLAC/fixed.c
+                    src/libFLAC/fixed_intrin_sse2.c
+                    src/libFLAC/fixed_intrin_ssse3.c
                     src/libFLAC/float.c
                     src/libFLAC/format.c
                     src/libFLAC/lpc.c
+                    src/libFLAC/lpc_intrin_avx2.c
+                    src/libFLAC/lpc_intrin_sse.c
+                    src/libFLAC/lpc_intrin_sse2.c
+                    src/libFLAC/lpc_intrin_sse41.c
                     src/libFLAC/md5.c
                     src/libFLAC/memory.c
                     src/libFLAC/metadata_iterators.c
@@ -43,12 +55,18 @@ set(LIBFLAC_SOURCES src/libFLAC/bitmath.c
                     src/libFLAC/stream_decoder.c
                     src/libFLAC/stream_encoder.c
                     src/libFLAC/stream_encoder_framing.c
+                    src/libFLAC/stream_encoder_intrin_avx2.c
+                    src/libFLAC/stream_encoder_intrin_sse2.c
+                    src/libFLAC/stream_encoder_intrin_ssse3.c
                     src/libFLAC/window.c
-                    src/libFLAC/ia32/bitreader_asm.obj
+                    src/libFLAC/windows_unicode_filenames.c)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+  list(APPEND LIBFLAC_SOURCES
                     src/libFLAC/ia32/cpu_asm.obj
                     src/libFLAC/ia32/fixed_asm.obj
-                    src/libFLAC/ia32/lpc_asm.obj
-                    src/libFLAC/ia32/stream_encoder_asm.obj)
+                    src/libFLAC/ia32/lpc_asm.obj)
+endif()
 
 include_directories(${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src/libFLAC/include ${CMAKE_INSTALL_PREFIX}/include)
 

--- a/depends/windows/flac/flac.txt
+++ b/depends/windows/flac/flac.txt
@@ -1,1 +1,1 @@
-flac http://mirrors.xbmc.org/build-deps/sources/flac-1.2.1.tar.gz
+flac http://mirrors.kodi.tv/build-deps/sources/flac-1.3.2.tar.xz


### PR DESCRIPTION
Only bumps flac for windows, other platforms not touched.