### PR TITLE
[travis] cmake move in kodi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,6 @@ before_script:
   - cd ${APPID}
   - mkdir build
   - cd build
-  - cmake -DADDONS_TO_BUILD=${APPID} -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/project/cmake/addons
+  - cmake -DADDONS_TO_BUILD=${APPID} -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons
 
 script: make


### PR DESCRIPTION
In xbmc/xbmc#10446 the cmake folder was moved from project directory to the root directory.