### PR TITLE
[depends] flac: fix android detection

### DIFF
--- a/depends/common/flac/02-relax-linux-OS-detection.patch
+++ b/depends/common/flac/02-relax-linux-OS-detection.patch
@@ -5,7 +5,7 @@
  
  case "$host" in
 -	*-pc-linux-gnu)
-+	*-linux-*)
++	*-pc-linux-gnu|*-linux-gnueabi*)
  		sys_linux=true
  		AC_DEFINE(FLAC__SYS_LINUX)
  		AH_TEMPLATE(FLAC__SYS_LINUX, [define if building for Linux])


### PR DESCRIPTION
#25 fix building for rbpi but broke android by accident.

The expression has to match `x86_64-pc-linux-gnu` and `arm-unknown-linux-gnueabihf` to work on linux and rbpi, but must not match `arm-unknown-linux-androideabi` and `aarch64-unknown-linux-android`.

This time I've tested it for linux and android. Jenkins already build the previous version correctly so it should still work.