### PR TITLE
[depends] use pre-compiled nasm instead of building it.

### DIFF
--- a/depends/windows/flac/CMakeLists.txt
+++ b/depends/windows/flac/CMakeLists.txt
@@ -2,6 +2,7 @@ project(flac)
 
 cmake_minimum_required(VERSION 2.8)
 
+find_program(NASM_COMPILER NAMES nasm nasmw)
 add_definitions(-DPACKAGE_VERSION="1.3.2"
                 -DFLAC__NO_DLL -DFLAC__ALIGN_MALLOC_DATA -DFLAC__HAS_OGG -DFLAC__HAS_X86INTRIN
                 -Dfseeko=_fseeki64 -Dftello=_ftelli64) # work around a bug in the code that leads to "undefined reference errors"
@@ -15,7 +16,7 @@ endif()
 # function to setup a custom command for a compiled assembler file
 function (build_nasm filename_we)
   add_custom_command(OUTPUT src/libFLAC/ia32/${filename_we}.obj
-                     COMMAND ${CMAKE_INSTALL_PREFIX}/bin/nasmw.exe -f win32 -d OBJ_FORMAT_win32 -i ${PROJECT_SOURCE_DIR}/src/libFLAC/ia32/ ${PROJECT_SOURCE_DIR}/src/libFLAC/ia32/${filename_we}.nasm -o ${PROJECT_BINARY_DIR}/src/libFLAC/ia32/${filename_we}.obj
+                     COMMAND ${NASM_COMPILER} -f win32 -d OBJ_FORMAT_win32 -i ${PROJECT_SOURCE_DIR}/src/libFLAC/ia32/ ${PROJECT_SOURCE_DIR}/src/libFLAC/ia32/${filename_we}.nasm -o ${PROJECT_BINARY_DIR}/src/libFLAC/ia32/${filename_we}.obj
                      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
 endfunction (build_nasm filename)
 

--- a/depends/windows/nasmw/CMakeLists.txt
+++ b/depends/windows/nasmw/CMakeLists.txt
@@ -1,16 +1,7 @@
+cmake_minimum_required(VERSION 2.8)
 project(nasmw)
 
-cmake_minimum_required(VERSION 2.8)
-
-include(ExternalProject)
-
-externalproject_add(nasmw
-                    SOURCE_DIR ${PROJECT_SOURCE_DIR}
-                    BINARY_DIR ${PROJECT_SOURCE_DIR}
-                    INSTALL_DIR ${PROJECT_SOURCE_DIR}
-                    CONFIGURE_COMMAND ""
-                    BUILD_COMMAND nmake /f Mkfiles/msvc.mak
-                    INSTALL_COMMAND "")
-
-install(PROGRAMS nasm.exe DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
-                          RENAME nasmw.exe)
+install(
+	DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/
+	DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+)

--- a/depends/windows/nasmw/nasmw.txt
+++ b/depends/windows/nasmw/nasmw.txt
@@ -1,1 +1,1 @@
-nasmw http://mirrors.xbmc.org/build-deps/sources/nasm-2.11.06.zip
+nasmw http://mirrors.kodi.tv/build-deps/win32/nasm-2.12.02-win32.zip

--- a/depends/windowsstore/flac/CMakeLists.txt
+++ b/depends/windowsstore/flac/CMakeLists.txt
@@ -7,6 +7,7 @@ check_symbol_exists(_X86_ "Windows.h" _X86_)
 check_symbol_exists(_AMD64_ "Windows.h" _X64_)
 check_symbol_exists(_ARM_ "Windows.h" _ARM_)
 
+find_program(NASM_COMPILER NAMES nasm nasmw)
 add_definitions(-DPACKAGE_VERSION="1.3.2"
                 -DFLAC__NO_DLL -DFLAC__ALIGN_MALLOC_DATA -DFLAC__HAS_OGG -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS
                 -Dfseeko=_fseeki64 -Dftello=_ftelli64) # work around a bug in the code that leads to "undefined reference errors"
@@ -24,7 +25,7 @@ endif()
 # function to setup a custom command for a compiled assembler file
 function (build_nasm filename_we)
   add_custom_command(OUTPUT src/libFLAC/ia32/${filename_we}.obj
-                     COMMAND ${CMAKE_INSTALL_PREFIX}/bin/nasm.exe -f win32 -d OBJ_FORMAT_win32 -i ${PROJECT_SOURCE_DIR}/src/libFLAC/ia32/ ${PROJECT_SOURCE_DIR}/src/libFLAC/ia32/${filename_we}.nasm -o ${PROJECT_BINARY_DIR}/src/libFLAC/ia32/${filename_we}.obj
+                     COMMAND ${NASM_COMPILER} -f win32 -d OBJ_FORMAT_win32 -i ${PROJECT_SOURCE_DIR}/src/libFLAC/ia32/ ${PROJECT_SOURCE_DIR}/src/libFLAC/ia32/${filename_we}.nasm -o ${PROJECT_BINARY_DIR}/src/libFLAC/ia32/${filename_we}.obj
                      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
 endfunction (build_nasm filename)
 


### PR DESCRIPTION
this also speed up built on windows platforms.