### PR TITLE
[debian] fix: re-add kodi-audioencoder-flac.install

### DIFF
--- a/debian/kodi-audioencoder-flac.install
+++ b/debian/kodi-audioencoder-flac.install
@@ -1,0 +1,2 @@
+usr/lib
+usr/share


### PR DESCRIPTION
https://github.com/xbmc/audioencoder.flac/pull/32 broke packaging