### PR TITLE
[Matrix] update travis ci status badge from org to com and update copyright year to 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a [Kodi](https://kodi.tv) FLAC audio encoder add-on.
 
 #### CI Testing
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
-[![Build Status](https://travis-ci.org/xbmc/audioencoder.flac.svg?branch=Matrix)](https://travis-ci.org/xbmc/audioencoder.flac/branches)
+[![Build Status](https://travis-ci.com/xbmc/audioencoder.flac.svg?branch=Matrix)](https://travis-ci.com/xbmc/audioencoder.flac/branches)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.audioencoder.flac?branchName=Matrix)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=21&branchName=Matrix)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/audioencoder.flac/job/Matrix/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Faudioencoder.flac/branches/)
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/5120/badge.svg)](https://scan.coverity.com/projects/5120)

--- a/debian/copyright
+++ b/debian/copyright
@@ -4,7 +4,7 @@ Source: https://github.com/xbmc/audioencoder.flac
 
 Files: *
 Copyright: Arne Morten Kvarving <arne.morten.kvarving@sintef.no>
-           2013-2020 Team Kodi
+           2013-2021 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -26,7 +26,7 @@ License: GPL-2+
 Files: debian/*
 Copyright: 2013 Arne Morten Kvarving <arne.morten.kvarving@sintef.no>
            2013 wsnipex <wsnipex@a1.net>
-           2013-2020 Team Kodi
+           2013-2021 Team Kodi
 License: GPL-2+
  This package is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/src/EncoderFlac.cpp
+++ b/src/EncoderFlac.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2020 Team Kodi (https://kodi.tv)
+ *  Copyright (C) 2005-2021 Team Kodi (https://kodi.tv)
  *
  *  SPDX-License-Identifier: GPL-2.0-or-later
  *  See LICENSE.md for more information.


### PR DESCRIPTION
As new as on before the satus badge was not updated