### PR TITLE
Fix for addon.xml.in and language files

### DIFF
--- a/audioencoder.flac/addon.xml.in
+++ b/audioencoder.flac/addon.xml.in
@@ -10,23 +10,15 @@
     extension=".flac"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
-
-FLAC ist der schnellste und am weitesten verbreitete verlustfreie Audio-Codec und der einzige, der gleichzeitig nicht proprietär ist, nicht durch Patente belastet ist, aus einer Open-Source-Referenzimplementierung besteht, über ein gut dokumentiertes API verfügt und über andere unabhängige Implementierungen verfügt.</description>
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations.</description>
+    <summary lang="de_DE">FLAC-Encoder (Free Lossless Audio Codec)</summary>
+    <summary lang="en_GB">FLAC (Free Lossless Audio Codec) Encoder</summary>
+    <description lang="de_DE">FLAC steht für Free Lossless Audio Codec, ein Audioformat ähnlich wie MP3, jedoch verlustfrei, was bedeutet, dass Audio in FLAC ohne Qualitätsverlust komprimiert wird. Dies ähnelt der Funktionsweise von Zip, außer dass Sie mit FLAC eine viel bessere Komprimierung erhalten, da es speziell für Audio entwickelt wurde und Sie komprimierte FLAC-Dateien nun in Ihrem Lieblingsplayer (oder in Ihrem Auto oder Ihrer Heimstereoanlage; siehe ünterstützte Geräte) wiedergeben können, als wären Sie eine MP3-Datei.[CR][CR]FLAC ist der schnellste und am weitesten verbreitete verlustfreie Audio-Codec und der einzige, der gleichzeitig nicht proprietär ist, nicht durch Patente belastet ist, aus einer Open-Source-Referenzimplementierung besteht, über ein gut dokumentiertes API verfügt und über andere unabhängige Implementierungen verfügt.</description>
+    <description lang="en_GB">FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.[CR][CR]FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations.</description>
     <platform>@PLATFORM@</platform>
     <license>GPL-2.0-or-later</license>
     <source>https://github.com/xbmc/audioencoder.flac</source>
     <assets>
       <icon>icon.png</icon>
     </assets>
-    <summary lang="de_DE">FLAC-Encoder (Free Lossless Audio Codec)</summary>
-    <summary lang="en_GB">FLAC (Free Lossless Audio Codec) Encoder</summary>
-    <description lang="de_DE">FLAC steht für Free Lossless Audio Codec, ein Audioformat ähnlich wie MP3, jedoch verlustfrei, was bedeutet, dass Audio in FLAC ohne Qualitätsverlust komprimiert wird. Dies ähnelt der Funktionsweise von Zip, außer dass Sie mit FLAC eine viel bessere Komprimierung erhalten, da es speziell für Audio entwickelt wurde und Sie komprimierte FLAC-Dateien nun in Ihrem Lieblingsplayer (oder in Ihrem Auto oder Ihrer Heimstereoanlage; siehe ünterstützte Geräte) wiedergeben können, als wären Sie eine MP3-Datei.
-
-FLAC ist der schnellste und am weitesten verbreitete verlustfreie Audio-Codec und der einzige, der gleichzeitig nicht proprietär ist, nicht durch Patente belastet ist, aus einer Open-Source-Referenzimplementierung besteht, über ein gut dokumentiertes API verfügt und über andere unabhängige Implementierungen verfügt.</description>
-    <description lang="en_GB">FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations.</description>
   </extension>
 </addon>

--- a/audioencoder.flac/resources/language/resource.language.af_za/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.af_za/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.am_et/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.am_et/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.ar_sa/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.ar_sa/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.ast_es/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.ast_es/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.az_az/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.az_az/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.be_by/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.be_by/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.bg_bg/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.bg_bg/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.bs_ba/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.bs_ba/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.ca_es/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.ca_es/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.cs_cz/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.cs_cz/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.cy_gb/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.cy_gb/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=(n==0) ? 0 : (n==1) ? 1 : (n==2) ? 2 : "
 "(n==3) ? 3 :(n==6) ? 4 : 5;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.da_dk/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.da_dk/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.6.1\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr "Komprimeringsniveau"

--- a/audioencoder.flac/resources/language/resource.language.de_de/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.de_de/strings.po
@@ -16,18 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr "FLAC-Encoder (Free Lossless Audio Codec)"
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr "FLAC steht für Free Lossless Audio Codec, ein Audioformat ähnlich wie MP3, jedoch verlustfrei, was bedeutet, dass Audio in FLAC ohne Qualitätsverlust komprimiert wird. Dies ähnelt der Funktionsweise von Zip, außer dass Sie mit FLAC eine viel bessere Komprimierung erhalten, da es speziell für Audio entwickelt wurde und Sie komprimierte FLAC-Dateien nun in Ihrem Lieblingsplayer (oder in Ihrem Auto oder Ihrer Heimstereoanlage; siehe ünterstützte Geräte) wiedergeben können, als wären Sie eine MP3-Datei.
-
-FLAC ist der schnellste und am weitesten verbreitete verlustfreie Audio-Codec und der einzige, der gleichzeitig nicht proprietär ist, nicht durch Patente belastet ist, aus einer Open-Source-Referenzimplementierung besteht, über ein gut dokumentiertes API verfügt und über andere unabhängige Implementierungen verfügt."
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr "Komprimierungspegel"

--- a/audioencoder.flac/resources/language/resource.language.el_gr/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.el_gr/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.en_au/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.en_au/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.en_gb/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.en_gb/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.en_nz/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.en_nz/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.en_us/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.en_us/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.eo/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.eo/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.es_ar/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.es_ar/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.es_es/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.es_es/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7.1\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr "Nivel de compresión"

--- a/audioencoder.flac/resources/language/resource.language.es_mx/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.es_mx/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5.3\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr "Nivel de compresión"

--- a/audioencoder.flac/resources/language/resource.language.et_ee/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.et_ee/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.eu_es/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.eu_es/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.fa_af/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.fa_af/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.fi_fi/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.fi_fi/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.fo_fo/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.fo_fo/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.fr_ca/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.fr_ca/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.fr_fr/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.fr_fr/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.gl_es/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.gl_es/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.he_il/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.he_il/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n == 2) ? 1 : ((n > 10 && "
 "n % 10 == 0) ? 2 : 3));\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.hi_in/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.hi_in/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.hr_hr/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.hr_hr/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.hu_hu/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.hu_hu/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.hy_am/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.hy_am/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.id_id/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.id_id/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.is_is/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.is_is/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n % 10 != 1 || n % 100 == 11;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.it_it/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.it_it/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.ja_jp/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.ja_jp/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.kl_gl/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.kl_gl/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.kn_in/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.kn_in/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.ko_kr/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.ko_kr/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.lt_lt/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.lt_lt/strings.po
@@ -18,16 +18,6 @@ msgstr ""
 "19)) ? 0 : ((n % 10 >= 2 && n % 10 <= 9 && (n % 100 < 11 || n % 100 > 19)) ? "
 "1 : 2);\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.lv_lv/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.lv_lv/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n % 10 == 0 || n % 100 >= 11 && n % 100 <= "
 "19) ? 0 : ((n % 10 == 1 && n % 100 != 11) ? 1 : 2);\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.mi/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.mi/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.mk_mk/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.mk_mk/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n==1 || n%10==1 ? 0 : 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.ml_in/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.ml_in/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.mn_mn/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.mn_mn/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.ms_my/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.ms_my/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.mt_mt/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.mt_mt/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=n==1 ? 0 : n==0 || ( n%100>1 && n%100<11) ? "
 "1 : (n%100>10 && n%100<20 ) ? 2 : 3;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.my_mm/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.my_mm/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.nb_no/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.nb_no/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.nl_nl/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.nl_nl/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.oc_fr/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.oc_fr/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.os_os/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.os_os/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.pl_pl/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.pl_pl/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.pt_br/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.pt_br/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.pt_pt/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.pt_pt/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.ro_md/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.ro_md/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n == 0 || n % 100 >= 2 && "
 "n % 100 <= 19) ? 1 : 2);\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.ro_ro/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.ro_ro/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
 "20)) ? 1 : 2;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.ru_ru/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.ru_ru/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.5.3\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr "Уровень сжатия"

--- a/audioencoder.flac/resources/language/resource.language.scn/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.scn/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.si_lk/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.si_lk/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.sk_sk/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.sk_sk/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.sl_si/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.sl_si/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
 "%100==4 ? 2 : 3;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.sq_al/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.sq_al/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.sr_rs/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.sr_rs/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.sr_rs@latin/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.sr_rs@latin/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.sv_se/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.sv_se/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.szl/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.szl/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.ta_in/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.ta_in/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.te_in/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.te_in/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.tg_tj/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.tg_tj/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.th_th/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.th_th/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.tr_tr/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.tr_tr/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7.1\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr "Sıkıştırma düzeyi"

--- a/audioencoder.flac/resources/language/resource.language.uk_ua/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.uk_ua/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.uz_uz/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.uz_uz/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.vi_vn/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.vi_vn/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""

--- a/audioencoder.flac/resources/language/resource.language.zh_cn/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.zh_cn/strings.po
@@ -17,16 +17,6 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.6.1\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr "压缩等级"

--- a/audioencoder.flac/resources/language/resource.language.zh_tw/strings.po
+++ b/audioencoder.flac/resources/language/resource.language.zh_tw/strings.po
@@ -16,16 +16,6 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-msgctxt "Addon Summary"
-msgid "FLAC (Free Lossless Audio Codec) Encoder"
-msgstr ""
-
-msgctxt "Addon Description"
-msgid "FLAC stands for Free Lossless Audio Codec, an audio format similar to MP3, but lossless, meaning that audio is compressed in FLAC without any loss in quality. This is similar to how Zip works, except with FLAC you will get much better compression because it is designed specifically for audio, and you can play back compressed FLAC files in your favorite player (or your car or home stereo, see supported devices) just like you would an MP3 file.
-
-FLAC stands out as the fastest and most widely supported lossless audio codec, and the only one that at once is non-proprietary, is unencumbered by patents, has an open-source reference implementation, has a well documented format and API, and has several other independent implementations."
-msgstr ""
-
 msgctxt "#30000"
 msgid "Compression level"
 msgstr ""


### PR DESCRIPTION
This fixes addon.xml to use `[CR]` instead of `\n`

It also removes description and summary from language files.

They will be created again by sync-addon-metadata-translations.yml